### PR TITLE
Improvements

### DIFF
--- a/app/admin/pay_slip.rb
+++ b/app/admin/pay_slip.rb
@@ -5,7 +5,7 @@ ActiveAdmin.register PaySlip do
   filter :month
   filter :year
 
-  actions :all, except: [:edit, :update, :destroy]
+  actions :all, except: [:edit, :show, :update]
 
   controller do
     def scoped_collection
@@ -33,6 +33,8 @@ ActiveAdmin.register PaySlip do
     column :year
     column :admin_user
     column :created_at
+
+    actions
   end
 
   form do |f|

--- a/app/jobs/send_pay_slip_job.rb
+++ b/app/jobs/send_pay_slip_job.rb
@@ -6,5 +6,9 @@ class SendPaySlipJob < ApplicationJob
     return unless associate && associate&.email
 
     PaySlipMailer.email_payslip(obj).deliver_now
+
+    if obj.send_concern_email_to_accounts?
+      AccountsMailer.incorrect_calculation_email(obj).deliver_now
+    end
   end
 end

--- a/app/mailers/accounts_mailer.rb
+++ b/app/mailers/accounts_mailer.rb
@@ -1,8 +1,9 @@
 class AccountsMailer < ApplicationMailer
   add_template_helper(ApplicationHelper)
 
-  default from: 'do-not-reply@kiprosh.com'
-  default to: Settings.mailer.test_accounts_email #|| 'accounts@kiprosh.com'
+  default from: 'do-not-reply@kiprosh.com',
+          to: Settings.mailer.test_accounts_email || 'accounts@kiprosh.com',
+          cc: Settings.mailer.cc_accounts_email
 
   def incorrect_calculation_email(obj)
     @obj = obj

--- a/app/mailers/accounts_mailer.rb
+++ b/app/mailers/accounts_mailer.rb
@@ -1,0 +1,15 @@
+class AccountsMailer < ApplicationMailer
+  add_template_helper(ApplicationHelper)
+
+  default from: 'do-not-reply@kiprosh.com'
+  default to: Settings.mailer.test_accounts_email #|| 'accounts@kiprosh.com'
+
+  def incorrect_calculation_email(obj)
+    @obj = obj
+    name = obj.associate.full_name
+    subject = "CONCERN - Calculation issues while processing pay slip for #{name}"
+
+    attachments["#{name}.pdf"] = attach_pay_slip(obj)
+    mail(subject: subject)
+  end
+end

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,4 +1,18 @@
 class ApplicationMailer < ActionMailer::Base
-  default from: 'from@example.com'
   layout 'mailer'
+
+  private
+
+  def attach_pay_slip(obj)
+    name = obj.associate.full_name
+
+    WickedPdf.new.pdf_from_string(
+      render_to_string(
+        pdf: "#{name}",
+        template: 'pay_slip_mailer/pay_slip_template.haml',
+        layout: 'mailer.html.erb',
+        locals: { obj: obj }
+      )
+    )
+  end
 end

--- a/app/mailers/pay_slip_mailer.rb
+++ b/app/mailers/pay_slip_mailer.rb
@@ -8,15 +8,7 @@ class PaySlipMailer < ApplicationMailer
     name = obj.associate.full_name
     subject = "Salary Slip - #{obj.pay_slip_period}"
 
-    attachments["#{name}.pdf"] = WickedPdf.new.pdf_from_string(
-      render_to_string(
-        pdf: "#{name}",
-        template: 'pay_slip_mailer/pay_slip_template.haml',
-        layout: 'mailer.html.erb',
-        locals: { obj: obj }
-      )
-    )
-
+    attachments["#{name}.pdf"] = attach_pay_slip(obj)
     mail(to: test_recipient || to, subject: subject)
   end
 

--- a/app/services/process_excel.rb
+++ b/app/services/process_excel.rb
@@ -9,25 +9,26 @@ class ProcessExcel
   end
 
   def process
+    opts = global_options
+
     CSV.parse(csv_string, headers: true).each do |row|
-      SendPaySlipJob.perform_later(month, year, row.to_h, global_options)
+      SendPaySlipJob.perform_later(month, year, row.to_h, opts)
     end
   end
 
   private
 
-  def earnings_to_exclude
-    exclude = ['basic pay'] # will be added in UI separately
-    exclude << 'special allowance' unless Configuration.enabled?('special_allowance')
-    exclude << 'telephone reimbusement' unless Configuration.enabled?('telephone_reimbusement')
-    exclude
+  def earnings_to_exclude_if_empty
+    exclude = []
+    exclude << Configuration.get_value('special_entries') if Configuration.get("special_entries").present?
+    exclude.flatten.reject(&:blank?)
   end
 
   def global_options
     {
       pf_rate: Configuration.get_value('pf_rate'),
       gratuity_rate: Configuration.get_value('gratuity_rate'),
-      excluded_earnings: earnings_to_exclude
+      earnings_to_exclude_if_empty: earnings_to_exclude_if_empty
     }
   end
 

--- a/app/views/accounts_mailer/incorrect_calculation_email.haml
+++ b/app/views/accounts_mailer/incorrect_calculation_email.haml
@@ -1,0 +1,29 @@
+%p Hello Sir,
+%p
+  While processing
+  %b #{@obj.pay_slip_period}
+  pay slip for our associate
+  %b #{@obj.associate_name},
+  we found issues with calculation.
+
+- if @obj.pf_amount_mismatch?
+  %p
+    PF amount in excel received is
+    %b Rs. #{@obj.pf_amount_from_excel},
+    whereas calculated value based on EPF rate of
+    %b #{@obj.pf_rate}%
+    comes out to be
+    %b Rs. #{@obj.calculated_pf_amount}.
+
+%p
+  Net amount comes out to be
+  %b Rs. #{@obj.calculated_net_amount}
+  as compared to
+  %b Rs. #{@obj.net_amount_in_excel}
+  in excel.
+
+%p Please take a note of this.
+
+%p PS: PFA pay slip of the associate.
+
+%p Thanks.

--- a/app/views/accounts_mailer/incorrect_calculation_email.haml
+++ b/app/views/accounts_mailer/incorrect_calculation_email.haml
@@ -1,5 +1,8 @@
 %p Hello Sir,
 %p
+  %b Needs immediate action / correction / verification.
+
+%p
   While processing
   %b #{@obj.pay_slip_period}
   pay slip for our associate
@@ -8,7 +11,7 @@
 
 - if @obj.pf_amount_mismatch?
   %p
-    PF amount in excel received is
+    PF amount in excel is
     %b Rs. #{@obj.pf_amount_from_excel},
     whereas calculated value based on EPF rate of
     %b #{@obj.pf_rate}%

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -16,3 +16,4 @@ delayed_jobs:
 mailer:
   test_recipient: "<%= ENV['EMAIL_TEST_RECIPIENT'] %>"
   test_accounts_email: "<%= ENV['TEST_ACCOUNTS_EMAIL'] %>"
+  cc_accounts_email: "<%= ENV['CC_ACCOUNTS_EMAIL'] %>"

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -15,3 +15,4 @@ delayed_jobs:
 
 mailer:
   test_recipient: "<%= ENV['EMAIL_TEST_RECIPIENT'] %>"
+  test_accounts_email: "<%= ENV['TEST_ACCOUNTS_EMAIL'] %>"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,4 +1,3 @@
 Configuration.create(key: 'gratuity_rate', value: { "value" => 4.81 })
 Configuration.create(key: 'pf_rate', value: { "value" => 12 })
-Configuration.create(key: 'special_allowance', value: {"enabled" => false })
-Configuration.create(key: 'telephone_reimbusement', value: {"enabled" => false })
+Configuration.create(key: 'special_entries', value: { "value" => ['special allowance', 'telephone reimbursement'] })


### PR DESCRIPTION
1. Display delete link against each PaySlip in ActiveAdmin view.
2. Calculate "Net Amount" on the fly.
3. Skip 'telephone reimbursement' and 'special allowance' when empty or zero.
4. Sending email to Accounts if there is issue with PF calculation.